### PR TITLE
Tab context menu with various Close... options

### DIFF
--- a/src/WinUI.Dock/Controls/DockTabItem.xaml
+++ b/src/WinUI.Dock/Controls/DockTabItem.xaml
@@ -8,6 +8,26 @@
              DropCompleted="OnDropCompleted"
              IsClosable="False"
              Style="{StaticResource TabViewItemStyle}">
+    <TabViewItem.Resources>
+        <x:String x:Key="CloseOthersMenuText">Close others</x:String>
+        <x:String x:Key="CloseAllLeftMenuText">Close others ←</x:String>
+        <x:String x:Key="CloseAllRightMenuText">Close others →</x:String>
+    </TabViewItem.Resources>
+
+    <TabViewItem.ContextFlyout>
+        <MenuFlyout Opening="TabContextMenu_Opening">
+            <MenuFlyoutItem x:Name="CloseOthersMenuItem"
+                            Click="CloseOthersMenuItem_Click"
+                            Text="{StaticResource CloseOthersMenuText}" />
+            <MenuFlyoutItem x:Name="CloseAllLeftMenuItem"
+                            Click="CloseAllLeftMenuItem_Click"
+                            Text="{StaticResource CloseAllLeftMenuText}" />
+            <MenuFlyoutItem x:Name="CloseAllRightMenuItem"
+                            Click="CloseAllRightMenuItem_Click"
+                            Text="{StaticResource CloseAllRightMenuText}" />
+        </MenuFlyout>
+    </TabViewItem.ContextFlyout>
+
     <TabViewItem.Header>
         <Grid x:Name="Tab"
               Padding="12,2,8,2"

--- a/src/WinUI.Dock/Controls/DockTabItem.xaml.cs
+++ b/src/WinUI.Dock/Controls/DockTabItem.xaml.cs
@@ -109,6 +109,42 @@ public sealed partial class DockTabItem : TabViewItem
         Document!.Root!.ActiveDocument = Document;
     }
 
+    private void TabContextMenu_Opening(object _, object __)
+    {
+        if (Document?.Owner is not DocumentGroup group)
+        {
+            return;
+        }
+
+        CloseOthersMenuItem.IsEnabled = group.CanCloseOtherTabs(Document);
+        CloseAllLeftMenuItem.IsEnabled = group.CanCloseTabsToLeft(Document);
+        CloseAllRightMenuItem.IsEnabled = group.CanCloseTabsToRight(Document);
+    }
+
+    private void CloseOthersMenuItem_Click(object _, RoutedEventArgs __)
+    {
+        if (Document?.Owner is DocumentGroup group)
+        {
+            group.CloseOtherTabs(Document);
+        }
+    }
+
+    private void CloseAllLeftMenuItem_Click(object _, RoutedEventArgs __)
+    {
+        if (Document?.Owner is DocumentGroup group)
+        {
+            group.CloseTabsToLeft(Document);
+        }
+    }
+
+    private void CloseAllRightMenuItem_Click(object _, RoutedEventArgs __)
+    {
+        if (Document?.Owner is DocumentGroup group)
+        {
+            group.CloseTabsToRight(Document);
+        }
+    }
+
     private void Pin_Click(object _, RoutedEventArgs __)
     {
         DockManager manager = Document!.Root!;

--- a/src/WinUI.Dock/Document.xaml.cs
+++ b/src/WinUI.Dock/Document.xaml.cs
@@ -23,9 +23,9 @@ public partial class Document : DockModule
                                                                                            new PropertyMetadata(false));
 
     public static readonly DependencyProperty CanCloseProperty = DependencyProperty.Register(nameof(CanClose),
-                                                                                             typeof(bool),
-                                                                                             typeof(Document),
-                                                                                             new PropertyMetadata(false));
+                                                                                              typeof(bool),
+                                                                                              typeof(Document),
+                                                                                              new PropertyMetadata(false));
 
     private static readonly DependencyProperty ActualTitleProperty = DependencyProperty.Register(nameof(ActualTitle),
                                                                                                  typeof(string),

--- a/src/WinUI.Dock/DocumentGroup.xaml.cs
+++ b/src/WinUI.Dock/DocumentGroup.xaml.cs
@@ -359,6 +359,48 @@ public partial class DocumentGroup : DockContainer
         Root!.Behavior?.OnDocked(document, this, dockTarget);
     }
 
+    internal bool CanCloseOtherTabs(Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        return CanCloseTabs(document, static (index, currentIndex) => index != currentIndex);
+    }
+
+    internal bool CanCloseTabsToLeft(Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        return CanCloseTabs(document, static (index, currentIndex) => index < currentIndex);
+    }
+
+    internal bool CanCloseTabsToRight(Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        return CanCloseTabs(document, static (index, currentIndex) => index > currentIndex);
+    }
+
+    internal void CloseOtherTabs(Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        CloseTabs(document, static (index, currentIndex) => index != currentIndex);
+    }
+
+    internal void CloseTabsToLeft(Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        CloseTabs(document, static (index, currentIndex) => index < currentIndex);
+    }
+
+    internal void CloseTabsToRight(Document document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        CloseTabs(document, static (index, currentIndex) => index > currentIndex);
+    }
+
     internal override void SaveLayout(JsonObject writer)
     {
         writer.WriteByModuleType(this);
@@ -380,6 +422,55 @@ public partial class DocumentGroup : DockContainer
         CompactTabs = reader[nameof(CompactTabs)].Deserialize<bool>();
         ShowWhenEmpty = reader[nameof(ShowWhenEmpty)].Deserialize<bool>();
         SelectedIndex = reader[nameof(SelectedIndex)].Deserialize<int>();
+    }
+
+    private bool CanCloseTabs(Document document, Func<int, int, bool> indexPredicate)
+    {
+        int currentIndex = Children.IndexOf(document);
+
+        return currentIndex is not -1
+            && Children.Cast<Document>().Any(item => item.CanClose && indexPredicate(Children.IndexOf(item), currentIndex));
+    }
+
+    private void CloseTabs(Document document, Func<int, int, bool> indexPredicate)
+    {
+        int currentIndex = Children.IndexOf(document);
+
+        if (currentIndex is -1)
+        {
+            return;
+        }
+
+        Document[] documents = Children.Cast<Document>()
+                                       .Where((item, index) => item.CanClose && indexPredicate(index, currentIndex))
+                                       .ToArray();
+
+        if (documents.Length is 0)
+        {
+            return;
+        }
+
+        DockManager? manager = Root;
+        bool activeDocumentWillClose = manager?.ActiveDocument is Document activeDocument && documents.Contains(activeDocument);
+
+        foreach (Document item in documents)
+        {
+            item.Detach();
+        }
+
+        if (manager is not null)
+        {
+            if (activeDocumentWillClose)
+            {
+                manager.ActiveDocument = Children.Contains(document)
+                    ? document
+                    : (SelectedIndex is not -1 ? (Document)Children[SelectedIndex] : null);
+            }
+
+            // In multi-window drag-and-drop operations, if the original window closes prematurely,
+            // it may lead to incorrect handling of the drop result.
+            FloatingWindowHelpers.CloseEmptyWindows(manager);
+        }
     }
 
     private void UpdateVisualState()

--- a/src/WinUI.Dock/DocumentGroup.xaml.cs
+++ b/src/WinUI.Dock/DocumentGroup.xaml.cs
@@ -359,47 +359,23 @@ public partial class DocumentGroup : DockContainer
         Root!.Behavior?.OnDocked(document, this, dockTarget);
     }
 
-    internal bool CanCloseOtherTabs(Document document)
-    {
-        ArgumentNullException.ThrowIfNull(document);
+    internal bool CanCloseOtherTabs(Document document) =>
+        CanCloseTabs(document, static (index, currentIndex) => index != currentIndex);
 
-        return CanCloseTabs(document, static (index, currentIndex) => index != currentIndex);
-    }
+    internal bool CanCloseTabsToLeft(Document document) =>
+        CanCloseTabs(document, static (index, currentIndex) => index < currentIndex);
 
-    internal bool CanCloseTabsToLeft(Document document)
-    {
-        ArgumentNullException.ThrowIfNull(document);
+    internal bool CanCloseTabsToRight(Document document) =>
+        CanCloseTabs(document, static (index, currentIndex) => index > currentIndex);
 
-        return CanCloseTabs(document, static (index, currentIndex) => index < currentIndex);
-    }
-
-    internal bool CanCloseTabsToRight(Document document)
-    {
-        ArgumentNullException.ThrowIfNull(document);
-
-        return CanCloseTabs(document, static (index, currentIndex) => index > currentIndex);
-    }
-
-    internal void CloseOtherTabs(Document document)
-    {
-        ArgumentNullException.ThrowIfNull(document);
-
+    internal void CloseOtherTabs(Document document) =>
         CloseTabs(document, static (index, currentIndex) => index != currentIndex);
-    }
 
-    internal void CloseTabsToLeft(Document document)
-    {
-        ArgumentNullException.ThrowIfNull(document);
-
+    internal void CloseTabsToLeft(Document document) =>
         CloseTabs(document, static (index, currentIndex) => index < currentIndex);
-    }
 
-    internal void CloseTabsToRight(Document document)
-    {
-        ArgumentNullException.ThrowIfNull(document);
-
+    internal void CloseTabsToRight(Document document) =>
         CloseTabs(document, static (index, currentIndex) => index > currentIndex);
-    }
 
     internal override void SaveLayout(JsonObject writer)
     {
@@ -435,7 +411,6 @@ public partial class DocumentGroup : DockContainer
     private void CloseTabs(Document document, Func<int, int, bool> indexPredicate)
     {
         int currentIndex = Children.IndexOf(document);
-
         if (currentIndex is -1)
         {
             return;


### PR DESCRIPTION
Propose to add a simple context menu with the typical fancy close options as seen in e.g. Notepad++; Close others, close all to left/right

<img width="174" height="173" alt="image" src="https://github.com/user-attachments/assets/ddfa8daa-ef5f-46d6-8aeb-8e6404a3deec" />

Fairly simple, hopefully you can merge this, so we have this available